### PR TITLE
Add support for private_key in connection extra

### DIFF
--- a/airflow_gpg_plugin/hooks/gpg_hook.py
+++ b/airflow_gpg_plugin/hooks/gpg_hook.py
@@ -4,7 +4,21 @@ from contextlib import contextmanager
 from typing import ContextManager
 
 import gnupg
+from airflow import AirflowException
 from airflow.hooks.base import BaseHook
+
+
+def extract_key_data(extra_options: dict) -> str:
+    key_file = extra_options.get('key_file')
+    if key_file is not None:
+        key_data = open(key_file).read()
+    else:
+        private_key = extra_options.get('private_key')
+        if private_key is not None:
+            key_data = private_key
+        else:
+            raise AirflowException("Either key_file or private_key must be present in connection extra")
+    return key_data
 
 
 class GpgHook(BaseHook):
@@ -20,9 +34,11 @@ class GpgHook(BaseHook):
     def get_conn(self) -> ContextManager[gnupg.GPG]:
         """Returns a connection object"""
         connection_obj = self.get_connection(self.gpg_conn_id)
-        key_data = open(connection_obj.extra_dejson['key_file']).read()
+        key_data = extract_key_data(connection_obj.extra_dejson)
         passphrase = connection_obj.password
+        return self.import_key(key_data, passphrase)
 
+    def import_key(self, key_data: str, passphrase: str) -> ContextManager[gnupg.GPG]:
         with tempfile.TemporaryDirectory() as gnupghome:
             self.log.info(f"Created temporary gnupghome directory {gnupghome}")
             gpg = gnupg.GPG(gnupghome=gnupghome)

--- a/tests/hooks/test_gpg_hook.py
+++ b/tests/hooks/test_gpg_hook.py
@@ -1,7 +1,9 @@
+from typing import Dict
+
 from airflow.models import Connection
 
 from airflow_gpg_plugin.hooks.gpg_hook import GpgHook
-from tests.conftest import create_connection
+from tests.conftest import register_connection
 
 
 def test_airflow_gpg_hook_with_passphrase_key(gpg_key_with_passphrase):
@@ -17,7 +19,7 @@ def test_airflow_gpg_hook_with_passphrase_key(gpg_key_with_passphrase):
         }
     )
 
-    create_connection(gpg_conn_id, conn)
+    register_connection(conn)
 
     hook = GpgHook(
         gpg_conn_id=gpg_conn_id
@@ -42,7 +44,7 @@ def test_airflow_gpg_hook_without_passphrase_key(gpg_key_without_passphrase):
         }
     )
 
-    create_connection(gpg_conn_id, conn)
+    register_connection(conn)
 
     hook = GpgHook(
         gpg_conn_id=gpg_conn_id
@@ -52,3 +54,28 @@ def test_airflow_gpg_hook_without_passphrase_key(gpg_key_without_passphrase):
         assert len(keys) == 1
         assert keys[0]["type"] == "pub"
         assert keys[0]["fingerprint"] == "DC81CBF472309E80AE9A02691D199764DF22F0CC"
+
+
+def test_airflow_gpg_hook_with_private_key(gpg_key_with_private_key: Dict[str, str]):
+    gpg_conn_id = "default_gpg_conn_with_private_key"
+
+    conn = Connection(
+        conn_id=gpg_conn_id,
+        conn_type=GpgHook.conn_type,
+        login=gpg_key_with_private_key["login"],
+        password=gpg_key_with_private_key["password"],
+        extra={
+            "private_key": gpg_key_with_private_key["private_key"]
+        }
+    )
+
+    register_connection(conn)
+
+    hook = GpgHook(
+        gpg_conn_id=gpg_conn_id
+    )
+    with hook.get_conn() as gpg_client:
+        keys = gpg_client.list_keys()
+        assert len(keys) == 1
+        assert keys[0]["type"] == "pub"
+        assert keys[0]["fingerprint"] == "818E2DFFE58AE74CB08EA374AD584D1465AF661F"


### PR DESCRIPTION
Following approach of Airflow ssh connection https://airflow.apache.org/docs/apache-airflow-providers-ssh/stable/connections/ssh.html I've added support to store gpg key in private_key of extra section of connection definition

We are using Cloud Composer (google cloud managed Airflow) it is unfeasible for us to use local files, especially for sensitive files like private keys.

